### PR TITLE
Fix Undefined index: REQUEST_METHOD when WP is called from CLI

### DIFF
--- a/class/advanced-excerpt.php
+++ b/class/advanced-excerpt.php
@@ -38,7 +38,7 @@ class Advanced_Excerpt {
 		$this->plugin_basename = plugin_basename( $plugin_file_path );
 		$this->plugin_base ='options-general.php?page=advanced-excerpt';
 
-		if ( 'POST' == $_SERVER['REQUEST_METHOD'] && isset( $_REQUEST['page'] ) && 'advanced-excerpt' === $_REQUEST['page'] ) {
+		if ( isset( $_SERVER['REQUEST_METHOD'] ) && 'POST' == $_SERVER['REQUEST_METHOD'] && isset( $_REQUEST['page'] ) && 'advanced-excerpt' === $_REQUEST['page'] ) {
 			check_admin_referer( 'advanced_excerpt_update_options' );
 			$this->update_options();
 		}

--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+  "name": "FancyThemes/wp-advanced-excerpt",
+  "description": "Advanced Excerpt",
+  "type": "wordpress-plugin",
+  "require": {}
+}


### PR DESCRIPTION
Fixed #44, but applies to 4.2.3 as released, not master.